### PR TITLE
fix: Correct broken link in navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -30,7 +30,7 @@ const Navbar = () => {
               </Link>
             </li>
             <li>
-              <Link href="/about#experience">
+              <Link href="/about.html#experience">
                 Experience
               </Link>
             </li>


### PR DESCRIPTION
This commit corrects the broken link to the experience section on the about page in the navbar.